### PR TITLE
Fixed typo for `createUniversalMacosFramework` task

### DIFF
--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateXCFrameworkTask.kt
@@ -139,7 +139,7 @@ internal fun Project.registerCreateXCFrameworkTask() = tasks.register("createXCF
         configuration.appleTargets.mapNotNull { it.getFramework(configuration.buildConfiguration) }.toMutableList()
 
     dependsOn(outputFrameworks.map { it.linkTask.name })
-    dependsOn("createUniversalMacosFramework")
+    dependsOn("createUniversalMacosSimulatorFramework")
     dependsOn("createUniversalIosSimulatorFramework")
     dependsOn("createUniversalWatchosSimulatorFramework")
     dependsOn("createUniversalTvosSimulatorFramework")


### PR DESCRIPTION
When running `:shared:createXCFramework`, I get:

```
Could not determine the dependencies of task ':shared:createXCFramework'.
> Task with path 'createUniversalMacosFramework' not found in project ':shared'.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
```

This PR should solve it as it was referencing the wrong name.