### PR TITLE
Add watchosDeviceArm64 target

### DIFF
--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/dsl/TargetPlatformDsl.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/dsl/TargetPlatformDsl.kt
@@ -47,6 +47,7 @@ public class TargetPlatformDsl {
                 Either.Right(TargetName.WatchOSarm64),
                 Either.Right(TargetName.WatchOSx86),
                 Either.Right(TargetName.WatchOSx64),
+                Either.Right(TargetName.WatchOSDeviceArm64),
                 Either.Right(TargetName.WatchOSSimulatorArm64)
             ),
             version


### PR DESCRIPTION
Added missing watchosDeviceArm64 target.
See https://youtrack.jetbrains.com/issue/KT-53107/Add-arm64-support-for-watchOS-targets-Xcode-14 for reference