### PR TITLE
Fix zip file task issue when project root is used as output directory…

### DIFF
--- a/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateZipFileTask.kt
+++ b/src/main/kotlin/com/chromaticnoise/multiplatformswiftpackage/task/CreateZipFileTask.kt
@@ -16,7 +16,7 @@ internal fun Project.registerCreateZipFileTask() {
         archiveFileName.set(configuration.zipFileName.nameWithExtension)
         destinationDirectory.set(outputDirectory)
         from(outputDirectory) {
-            include("**/*.xcframework/")
+            include("${configuration.packageName.value}.xcframework/")
         }
     }
 }


### PR DESCRIPTION
…. Fixes #20

The wildcard that was used in the include was too permissive and would cause too many things to be zipped when the output directory was set to be the project root.

See issue #20 for more info.